### PR TITLE
Use hostname not host from JS URL

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -134,7 +134,7 @@ const uri_from_url = (url) => {
   return new Uri(
     /* scheme   */ url.protocol ? new Some(url.protocol) : new None(),
     /* userinfo */ new None(),
-    /* host     */ url.host ? new Some(url.host) : new None(),
+    /* host     */ url.hostname ? new Some(url.hostname) : new None(),
     /* port     */ url.port ? new Some(Number(url.port)) : new None(),
     /* path     */ url.pathname,
     /* query    */ url.search ? new Some(url.search.slice(1)) : new None(),


### PR DESCRIPTION
In a Javascript, the `host` of a URL is the `hostname` [plus the port followed by a `:` if the port is non-empty](https://developer.mozilla.org/en-US/docs/Web/API/URL/host).

Gleam's `Uri`s don't have this distinction between `host` and `hostname` but confusingly the `host` field looks like it matches the `hostname` from a JS URL by excluding the port.

```gleam
let assert Ok(uri) = uri.parse("http://localhost:1234/abc?q=5#frag")
io.debug(uri)


// Uri(scheme: Some("http"), userinfo: None, host: Some("localhost"), port: Some(1234), path: "/abc", query: Some("q=5"), fragment: Some("frag"))
```

```js
new URL("http://localhost:1234/abc?q=5#frag")

// { href: "http://localhost:1234/abc?q=5#frag", origin: "http://localhost:1234/", protocol: "http:", username: "", password: "", host: "localhost:1234", hostname: "localhost", port: "1234", pathname: "/abc", search: "?q=5" }
```