### PR TITLE
remove trailing `:` from url.protocol

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -144,7 +144,7 @@ const find_anchor = (el) => {
 
 const uri_from_url = (url) => {
   return new Uri(
-    /* scheme   */ url.protocol ? new Some(url.protocol) : new None(),
+    /* scheme   */ url.protocol ? new Some(url.protocol.slice(0, -1)) : new None(),
     /* userinfo */ new None(),
     /* host     */ url.hostname ? new Some(url.hostname) : new None(),
     /* port     */ url.port ? new Some(Number(url.port)) : new None(),


### PR DESCRIPTION
MDN says the `:` is to be expected: https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol

`gleam/url` seems to not expect it: https://github.com/gleam-lang/stdlib/blob/7aba73d83c42763e1854dd4a0beb0f17fb8b4019/src/gleam/uri.gleam#L45