### PR TITLE
Use globalThis to access window

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -9,7 +9,7 @@ const defaults = {
   handle_internal_links: true,
 };
 
-const initial_location = window?.location?.href;
+const initial_location = globalThis?.window?.location?.href;
 
 // EXPORTS ---------------------------------------------------------------------
 


### PR DESCRIPTION
Modem crashes when importing on server environments, iex: server rendering lustre using node. By using `globalThis` we can get window both on server and client on the same way.

It should fix issue #9 