### PR TITLE
Improve open in new tab behaviour

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -30,7 +30,7 @@ export const do_init = (dispatch, options = defaults) => {
     try {
       const url = new URL(a.href);
       const uri = uri_from_url(url);
-      const is_external = url.host !== window.location.host;
+      const is_external = url.host !== window.location.host || a.target === "_blank";
 
       if (!options.handle_external_links && is_external) return;
       if (!options.handle_internal_links && !is_external) return;


### PR DESCRIPTION
We sometimes want to open an internal link in a new tab. 
This PR updates the JS behaviour to treat links with `target === "_blank"` as external