### PR TITLE
Make options defaults clearer

### DIFF
--- a/src/modem.gleam
+++ b/src/modem.gleam
@@ -51,6 +51,7 @@ pub type Options {
     ///
     /// You will need to manually call [`load`](#load) to actually navigate to
     /// the external link!
+    ///
     handle_external_links: Bool,
   )
 }


### PR DESCRIPTION
In particular, `handle_internal_links` read as if it is false by default, but it is True.

Thank you! :heart: