### PR TITLE
allow browser to handle modifier+clicks natively (e.g. new tab)

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -35,6 +35,9 @@ export const do_init = (dispatch, options = defaults) => {
       if (!options.handle_external_links && is_external) return;
       if (!options.handle_internal_links && !is_external) return;
 
+      // Allow browser to handle modifier+clicks natively (new tab, new window, etc.)
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
       event.preventDefault();
 
       if (!is_external) {


### PR DESCRIPTION
It's something that I wanted in my application. Unsure if this is interesting to everyone and whether this should be default behaviour or somehow configurable. Sending this PR for your consideration.
