### PR TITLE
Add opt-in handling for modified link clicks

### DIFF
--- a/src/modem.ffi.mjs
+++ b/src/modem.ffi.mjs
@@ -7,6 +7,7 @@ import { Uri, to_string } from "../gleam_stdlib/gleam/uri.mjs";
 const defaults = {
   handle_external_links: false,
   handle_internal_links: true,
+  handle_modified_clicks: false,
 };
 
 const initial_location = globalThis?.window?.location?.href;
@@ -32,9 +33,12 @@ export const do_init = (dispatch, options = defaults) => {
     const uri = uri_from_url(url);
     const is_external =
       url.host !== window.location.host || a.target === "_blank";
+    const is_modified_click =
+      event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
 
     if (!options.handle_external_links && is_external) return;
     if (!options.handle_internal_links && !is_external) return;
+    if (!options.handle_modified_clicks && is_modified_click) return;
     if (a.hasAttribute("download")) return;
 
     event.preventDefault();

--- a/src/modem.gleam
+++ b/src/modem.gleam
@@ -53,6 +53,12 @@ pub type Options {
     /// the external link!
     ///
     handle_external_links: Bool,
+    /// This option controls if modified browser clicks such as cmd-click,
+    /// ctrl-click, shift-click, or alt-click should trigger your url change
+    /// handler. When disabled, modem ignores these clicks and preserves the
+    /// browser's default behaviour.
+    ///
+    handle_modified_clicks: Bool,
   )
 }
 


### PR DESCRIPTION
I noticed cmd-click did not work as expected in the app I'm working on. This PR makes the behavior opt-in.

I made it an option as you suggested in https://github.com/hayleigh-dot-dev/modem/pull/20. Feel free to close this if the first PR follows up.